### PR TITLE
Update cache.md

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -397,7 +397,7 @@ We just need to implement each of these methods using a MongoDB connection. For 
 <a name="registering-the-driver"></a>
 ### Registering The Driver
 
-To register the custom cache driver with Laravel, we will use the `extend` method on the `Cache` facade. The call to `Cache::extend` could be done in the `boot` method of the default `App\Providers\AppServiceProvider` that ships with fresh Laravel applications, or you may create your own service provider to house the extension - just don't forget to register the provider in the `config/app.php` provider array:
+To register the custom cache driver with Laravel, we will use the `extend` method on the `Cache` facade. The call to `Cache::extend` should be done using the app's booting hook in the `register` method of the default `App\Providers\AppServiceProvider` that ships with fresh Laravel applications, or you may create your own service provider to house the extension. This ensures that any other Service Provider that may need to retrieve values from cache will have the new custom driver available - just don't forget to register the provider in the `config/app.php` provider array:
 
     <?php
 
@@ -416,7 +416,11 @@ To register the custom cache driver with Laravel, we will use the `extend` metho
          */
         public function register()
         {
-            //
+            $this->app->booting(function () {
+                Cache::extend('mongo', function ($app) {
+                    return Cache::repository(new MongoStore);
+                });
+            });
         }
 
         /**
@@ -426,9 +430,7 @@ To register the custom cache driver with Laravel, we will use the `extend` metho
          */
         public function boot()
         {
-            Cache::extend('mongo', function ($app) {
-                return Cache::repository(new MongoStore);
-            });
+            //
         }
     }
 


### PR DESCRIPTION
This PR addresses a potential problem when using as default a custom cache driver.
By registering drivers in the boot method of an ApplicationServiceProvider as currently recommended in the docs, the driver may not available to other services that need retrieving values from cache, services that run in boot methods from other service providers. This can happen due to load order of the providers.